### PR TITLE
fix logo font into vectors instead of text

### DIFF
--- a/assets/images/logo-horizontal-darkbg.svg
+++ b/assets/images/logo-horizontal-darkbg.svg
@@ -170,7 +170,7 @@
      inkscape:pageshadow="2"
      inkscape:zoom="1"
      inkscape:cx="423.52311"
-     inkscape:cy="129.9128"
+     inkscape:cy="127.9128"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      inkscape:document-rotation="0"
@@ -180,11 +180,11 @@
      fit-margin-right="3"
      fit-margin-bottom="3"
      lock-margins="true"
-     inkscape:window-width="1920"
+     inkscape:window-width="3840"
      inkscape:window-height="1136"
-     inkscape:window-x="1920"
+     inkscape:window-x="0"
      inkscape:window-y="27"
-     inkscape:window-maximized="0" />
+     inkscape:window-maximized="1" />
   <metadata
      id="metadata1918">
     <rdf:RDF>
@@ -193,7 +193,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -234,97 +234,57 @@
          id="g3793"
          transform="matrix(-3.3250748,0,0,1.9530604,2181.3948,-295.25744)"
          style="fill:#000000;stroke:none;stroke-width:0.624536;filter:url(#filter3350)">
-        <rect
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+        <path
            id="rect3789"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.2750445" />
-        <rect
-           style="opacity:0.900599;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.12267 0.16156,0.27504 v 1.2203 c 0,0.15238 -0.0721,0.27505 -0.16156,0.27505 h -0.66292 c -0.0895,0 -0.16155,-0.12267 -0.16155,-0.27505 v -1.2203 c 0,-0.15237 0.072,-0.27504 0.16155,-0.27504 z" />
+        <path
            id="rect3791"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.2750445"
-           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)" />
+           style="opacity:0.900599;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.12267 0.16156,0.27504 v 1.2203 c 0,0.15238 -0.0721,0.27505 -0.16156,0.27505 h -0.66292 c -0.0895,0 -0.16155,-0.12267 -0.16155,-0.27505 v -1.2203 c 0,-0.15237 0.072,-0.27504 0.16155,-0.27504 z" />
       </g>
       <g
          id="g3799"
          transform="matrix(3.3250748,0,0,1.9530604,-1286.1282,-342.54035)"
          style="fill:#000000;stroke:none;stroke-width:0.624536;filter:url(#filter3350)">
-        <rect
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+        <path
            id="rect3795"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.2750445" />
-        <rect
-           style="opacity:0.900599;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.12267 0.16156,0.27504 v 1.2203 c 0,0.15238 -0.0721,0.27505 -0.16156,0.27505 h -0.66292 c -0.0895,0 -0.16155,-0.12267 -0.16155,-0.27505 v -1.2203 c 0,-0.15237 0.072,-0.27504 0.16155,-0.27504 z" />
+        <path
            id="rect3797"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.2750445"
-           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)" />
+           style="opacity:0.900599;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.12267 0.16156,0.27504 v 1.2203 c 0,0.15238 -0.0721,0.27505 -0.16156,0.27505 h -0.66292 c -0.0895,0 -0.16155,-0.12267 -0.16155,-0.27505 v -1.2203 c 0,-0.15237 0.072,-0.27504 0.16155,-0.27504 z" />
       </g>
       <g
          id="g3805"
          transform="matrix(3.3250748,0,0,3.2434977,-1286.3928,-811.05984)"
          style="stroke-width:0.484628">
-        <rect
-           style="opacity:1;fill:url(#radialGradient3815);fill-opacity:1;stroke:#000000;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+        <path
            id="rect3801"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.16561705" />
-        <rect
-           style="opacity:0.900599;fill:url(#linearGradient3817);fill-opacity:1;stroke:none;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           style="opacity:1;fill:url(#radialGradient3815);fill-opacity:1;stroke:#000000;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.0739 0.16156,0.16562 v 1.43915 c 0,0.0917 -0.0721,0.16562 -0.16156,0.16562 h -0.66292 c -0.0895,0 -0.16155,-0.0739 -0.16155,-0.16562 v -1.43915 c 0,-0.0917 0.072,-0.16562 0.16155,-0.16562 z" />
+        <path
            id="rect3803"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.16561705"
-           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)" />
+           style="opacity:0.900599;fill:url(#linearGradient3817);fill-opacity:1;stroke:none;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.0739 0.16156,0.16562 v 1.43915 c 0,0.0917 -0.0721,0.16562 -0.16156,0.16562 h -0.66292 c -0.0895,0 -0.16155,-0.0739 -0.16155,-0.16562 v -1.43915 c 0,-0.0917 0.072,-0.16562 0.16155,-0.16562 z" />
       </g>
       <g
          id="g3811"
          transform="matrix(3.3250748,0,0,3.2434977,-1286.2236,-763.9026)"
          style="stroke-width:0.484628">
-        <rect
-           style="opacity:1;fill:url(#radialGradient3819);fill-opacity:1;stroke:#000000;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+        <path
            id="rect3807"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.16561705" />
-        <rect
-           style="opacity:0.900599;fill:url(#linearGradient3821);fill-opacity:1;stroke:none;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           style="opacity:1;fill:url(#radialGradient3819);fill-opacity:1;stroke:#000000;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.0739 0.16156,0.16562 v 1.43915 c 0,0.0917 -0.0721,0.16562 -0.16156,0.16562 h -0.66292 c -0.0895,0 -0.16155,-0.0739 -0.16155,-0.16562 v -1.43915 c 0,-0.0917 0.072,-0.16562 0.16155,-0.16562 z" />
+        <path
            id="rect3809"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.16561705"
-           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)" />
+           style="opacity:0.900599;fill:url(#linearGradient3821);fill-opacity:1;stroke:none;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.0739 0.16156,0.16562 v 1.43915 c 0,0.0917 -0.0721,0.16562 -0.16156,0.16562 h -0.66292 c -0.0895,0 -0.16155,-0.0739 -0.16155,-0.16562 v -1.43915 c 0,-0.0917 0.072,-0.16562 0.16155,-0.16562 z" />
       </g>
     </g>
     <g
@@ -359,97 +319,57 @@
          id="g3358"
          transform="matrix(-3.3250748,0,0,1.9530604,2181.3948,-295.25744)"
          style="fill:#000000;stroke:none;stroke-width:0.624536;filter:url(#filter3350)">
-        <rect
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+        <path
            id="rect3354"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.2750445" />
-        <rect
-           style="opacity:0.900599;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.12267 0.16156,0.27504 v 1.2203 c 0,0.15238 -0.0721,0.27505 -0.16156,0.27505 h -0.66292 c -0.0895,0 -0.16155,-0.12267 -0.16155,-0.27505 v -1.2203 c 0,-0.15237 0.072,-0.27504 0.16155,-0.27504 z" />
+        <path
            id="rect3356"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.2750445"
-           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)" />
+           style="opacity:0.900599;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.12267 0.16156,0.27504 v 1.2203 c 0,0.15238 -0.0721,0.27505 -0.16156,0.27505 h -0.66292 c -0.0895,0 -0.16155,-0.12267 -0.16155,-0.27505 v -1.2203 c 0,-0.15237 0.072,-0.27504 0.16155,-0.27504 z" />
       </g>
       <g
          id="g3248"
          transform="matrix(3.3250748,0,0,1.9530604,-1286.1282,-342.54035)"
          style="fill:#000000;stroke:none;stroke-width:0.624536;filter:url(#filter3350)">
-        <rect
-           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+        <path
            id="rect3244"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.2750445" />
-        <rect
-           style="opacity:0.900599;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.12267 0.16156,0.27504 v 1.2203 c 0,0.15238 -0.0721,0.27505 -0.16156,0.27505 h -0.66292 c -0.0895,0 -0.16155,-0.12267 -0.16155,-0.27505 v -1.2203 c 0,-0.15237 0.072,-0.27504 0.16155,-0.27504 z" />
+        <path
            id="rect3246"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.2750445"
-           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)" />
+           style="opacity:0.900599;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.0624536;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.12267 0.16156,0.27504 v 1.2203 c 0,0.15238 -0.0721,0.27505 -0.16156,0.27505 h -0.66292 c -0.0895,0 -0.16155,-0.12267 -0.16155,-0.27505 v -1.2203 c 0,-0.15237 0.072,-0.27504 0.16155,-0.27504 z" />
       </g>
       <g
          id="g5137-6"
          transform="matrix(3.3250748,0,0,3.2434977,-1286.3928,-811.05984)"
          style="stroke-width:0.484628">
-        <rect
-           style="opacity:1;fill:url(#radialGradient5031-7);fill-opacity:1;stroke:#000000;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+        <path
            id="rect5023-1"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.16561705" />
-        <rect
-           style="opacity:0.900599;fill:url(#linearGradient5147-9);fill-opacity:1;stroke:none;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           style="opacity:1;fill:url(#radialGradient5031-7);fill-opacity:1;stroke:#000000;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.0739 0.16156,0.16562 v 1.43915 c 0,0.0917 -0.0721,0.16562 -0.16156,0.16562 h -0.66292 c -0.0895,0 -0.16155,-0.0739 -0.16155,-0.16562 v -1.43915 c 0,-0.0917 0.072,-0.16562 0.16155,-0.16562 z" />
+        <path
            id="rect5033-0"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.16561705"
-           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)" />
+           style="opacity:0.900599;fill:url(#linearGradient5147-9);fill-opacity:1;stroke:none;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.0739 0.16156,0.16562 v 1.43915 c 0,0.0917 -0.0721,0.16562 -0.16156,0.16562 h -0.66292 c -0.0895,0 -0.16155,-0.0739 -0.16155,-0.16562 v -1.43915 c 0,-0.0917 0.072,-0.16562 0.16155,-0.16562 z" />
       </g>
       <g
          id="g3120"
          transform="matrix(3.3250748,0,0,3.2434977,-1286.2236,-763.9026)"
          style="stroke-width:0.484628">
-        <rect
-           style="opacity:1;fill:url(#radialGradient3122);fill-opacity:1;stroke:#000000;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+        <path
            id="rect3116"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.16561705" />
-        <rect
-           style="opacity:0.900599;fill:url(#linearGradient3124);fill-opacity:1;stroke:none;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           style="opacity:1;fill:url(#radialGradient3122);fill-opacity:1;stroke:#000000;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.0739 0.16156,0.16562 v 1.43915 c 0,0.0917 -0.0721,0.16562 -0.16156,0.16562 h -0.66292 c -0.0895,0 -0.16155,-0.0739 -0.16155,-0.16562 v -1.43915 c 0,-0.0917 0.072,-0.16562 0.16155,-0.16562 z" />
+        <path
            id="rect3118"
-           width="0.986027"
-           height="1.7703857"
-           x="520.90857"
-           y="362.05484"
-           rx="0.1615538"
-           ry="0.16561705"
-           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)" />
+           style="opacity:0.900599;fill:url(#linearGradient3124);fill-opacity:1;stroke:none;stroke-width:0.0484628;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5123-9);stop-color:#000000"
+           transform="matrix(0.82661339,0,0,0.82661339,90.362213,62.925818)"
+           d="m 521.07012,362.05484 h 0.66292 c 0.0895,0 0.16156,0.0739 0.16156,0.16562 v 1.43915 c 0,0.0917 -0.0721,0.16562 -0.16156,0.16562 h -0.66292 c -0.0895,0 -0.16155,-0.0739 -0.16155,-0.16562 v -1.43915 c 0,-0.0917 0.072,-0.16562 0.16155,-0.16562 z" />
       </g>
     </g>
     <g
@@ -480,13 +400,10 @@
            id="g2754"
            transform="matrix(0.42823078,0,0,0.03588626,-82.349033,-6.213123)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2752"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <path
            id="path2756"
@@ -502,55 +419,68 @@
            id="g2762"
            transform="matrix(0.42775623,0,0,0.03588626,-40.261946,-6.213123)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2760"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <g
            id="g2766"
            transform="matrix(0.42823078,0,0,0.03588626,-82.349033,10.521363)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2764"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <g
            id="g2770"
            transform="matrix(0.42775623,0,0,0.03588626,-40.261946,10.521363)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2768"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
       </g>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:7.41456px;line-height:0;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.185365"
-         x="-500.95859"
-         y="26.60891"
-         id="text2790"><tspan
-           sodipodi:role="line"
-           x="-500.95859"
-           y="26.60891"
+      <g
+         aria-label="PLUMBING
+"
+         id="text2790"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:7.41456px;line-height:0;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.185365">
+        <path
+           d="m -519.2651,26.60891 v -5.190192 h 2.73597 l 0.86009,0.496775 v 2.313343 l -0.86009,0.496775 h -1.69793 v 1.883299 z m 1.03804,-4.300445 v 1.527399 h 1.51998 v -1.527399 z"
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
-           id="tspan2786">PLUMBING</tspan><tspan
-           sodipodi:role="line"
-           x="-500.95859"
-           y="34.072727"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.82704px;line-height:0.4;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
-           id="tspan2788" /></text>
+           id="path1648" />
+        <path
+           d="m -514.63101,26.60891 v -5.190192 h 1.03803 v 4.300444 h 1.77208 v 0.889748 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1650" />
+        <path
+           d="m -508.00241,21.418718 h 1.03804 v 4.730489 l -0.86009,0.496775 h -2.32076 l -0.86009,-0.496775 v -4.730489 h 1.03804 v 4.263372 h 1.96486 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1652" />
+        <path
+           d="m -501.33673,26.60891 v -3.425527 h -0.0148 l -1.1715,3.425527 h -0.98614 l -1.17891,-3.470014 h -0.0148 v 3.470014 h -1.00097 v -5.190192 h 1.37911 l 1.30496,3.818498 h 0.0148 l 1.29755,-3.818498 h 1.37169 v 5.190192 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1654" />
+        <path
+           d="m -495.40509,23.546696 -0.64507,0.370728 v 0.01483 l 0.64507,0.370727 v 1.809153 l -0.86009,0.496776 h -2.81012 v -5.190192 h 2.81012 l 0.86009,0.496775 z m -2.63217,0.823017 v 1.349449 h 1.59413 v -1.349449 z m 0,-2.061248 v 1.1715 h 1.59413 v -1.1715 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1656" />
+        <path
+           d="m -494.14462,26.60891 v -5.190192 h 1.03803 v 5.190192 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1658" />
+        <path
+           d="m -490.80808,23.250114 v 3.358796 h -1.03803 v -5.190192 h 0.9713 l 2.2392,3.358795 h 0.0148 v -3.358795 h 1.03804 v 5.190192 h -0.97131 l -2.2392,-3.358796 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1660" />
+        <path
+           d="m -484.46863,24.792342 v -0.889747 h 1.89071 v 2.246612 l -0.86009,0.496775 h -2.09832 l -0.86009,-0.496775 V 21.87842 l 0.86009,-0.496775 h 2.09832 l 0.86009,0.496775 v 1.060282 h -1.03804 v -0.66731 h -1.74242 v 3.484843 h 1.74242 v -0.963893 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1662" />
+      </g>
       <g
          id="g3018"
          transform="translate(-51.450429,18.520832)"
@@ -559,66 +489,100 @@
            id="g3006"
            style="opacity:0.736082;fill:#ffffff;fill-opacity:1"
            transform="matrix(-1.1061792,0,0,1.1061792,-624.48914,-29.465818)">
-          <rect
-             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2996"
-             width="2.7561522"
-             height="0.19935799"
-             x="141.00124"
-             y="27.404345"
-             transform="scale(-1,1)" />
-          <text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832"
-             x="141.05009"
-             y="26.128925"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             transform="scale(-1,1)"
+             d="m 141.00124,27.404345 h 2.75615 v 0.199358 h -2.75615 z" />
+          <g
+             aria-label="4010
+42G1
+"
+             transform="scale(-1,1)"
              id="text3004"
-             transform="scale(-1,1)"><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="26.128925"
+             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832">
+            <path
+               d="m 141.58384,25.965101 v 0.163824 h -0.14585 v -0.163824 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 v -0.238866 h -0.002 l -0.18496,0.236752 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan2998">4010</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="27.087183"
+               id="path1666" />
+            <path
+               d="m 142.34589,26.063396 -0.1226,0.07081 h -0.28855 l -0.1226,-0.07081 v -0.608792 l 0.1226,-0.07081 h 0.28855 l 0.1226,0.07081 z m -0.38578,-0.552775 v 0.496757 h 0.23781 v -0.496757 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3000">42G1</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="28.045443"
+               id="path1668" />
+            <path
+               d="m 142.52557,25.636396 v -0.138458 l 0.19024,-0.108864 h 0.12684 v 0.61302 h 0.16911 v 0.126831 h -0.48619 v -0.126831 h 0.16911 v -0.462936 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3002" /></text>
+               id="path1670" />
+            <path
+               d="m 143.67234,26.063396 -0.12261,0.07081 h -0.28854 l -0.1226,-0.07081 v -0.608792 l 0.1226,-0.07081 h 0.28854 l 0.12261,0.07081 z m -0.38578,-0.552775 v 0.496757 h 0.23781 v -0.496757 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1672" />
+            <path
+               d="m 141.58384,26.92336 v 0.163824 h -0.14585 V 26.92336 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 V 26.56506 h -0.002 l -0.18496,0.236753 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1674" />
+            <path
+               d="m 141.96011,26.960352 h 0.34879 v 0.126832 h -0.49676 v -0.34773 l 0.1226,-0.07081 h 0.22619 v -0.194476 h -0.20082 v 0.09512 h -0.14797 v -0.151141 l 0.1226,-0.07081 h 0.25155 l 0.12261,0.07081 v 0.30651 l -0.12261,0.07081 h -0.22618 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1676" />
+            <path
+               d="m 142.75281,26.828236 v -0.126832 h 0.26951 v 0.32025 l -0.1226,0.07081 h -0.29911 l -0.1226,-0.07081 v -0.608791 l 0.1226,-0.07082 h 0.29911 l 0.1226,0.07082 v 0.15114 h -0.14797 v -0.09512 h -0.24837 v 0.496757 h 0.24837 v -0.137401 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1678" />
+            <path
+               d="m 143.19143,26.594654 v -0.138457 l 0.19025,-0.108864 h 0.12683 v 0.613019 h 0.16911 v 0.126832 h -0.48619 v -0.126832 h 0.16911 v -0.462935 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1680" />
+          </g>
         </g>
         <g
            id="g3016"
            style="opacity:0.736082;fill:#ffffff;fill-opacity:1"
            transform="matrix(-1.1061792,0,0,1.1061792,-589.15206,-17.983519)">
-          <rect
-             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3008"
-             width="2.7561522"
-             height="0.19935799"
-             x="141.00124"
-             y="27.404345"
-             transform="scale(-1,1)" />
-          <text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832"
-             x="141.05009"
-             y="26.128925"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             transform="scale(-1,1)"
+             d="m 141.00124,27.404345 h 2.75615 v 0.199358 h -2.75615 z" />
+          <g
+             aria-label="6488
+9084"
+             transform="scale(-1,1)"
              id="text3014"
-             transform="scale(-1,1)"><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="26.128925"
+             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832">
+            <path
+               d="m 141.2879,25.510621 v 0.212443 l 0.0751,-0.04333 h 0.15642 l 0.12261,0.07081 v 0.312852 l -0.12261,0.07081 h -0.25683 l -0.12261,-0.07081 v -0.608792 l 0.12261,-0.07081 h 0.25683 l 0.12261,0.07081 v 0.151141 h -0.14797 v -0.09512 z m 0,0.295941 v 0.200816 h 0.20611 v -0.200816 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3010">6488</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="27.087183"
+               id="path1684" />
+            <path
+               d="m 142.26556,25.965101 v 0.163824 h -0.14585 v -0.163824 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 v -0.238866 h -0.002 l -0.18496,0.236752 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3012">9084</tspan></text>
+               id="path1686" />
+            <path
+               d="m 142.64183,26.007378 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324477 h 0.21667 v -0.17228 h -0.21667 z m 0.24204,0.451309 h -0.28432 l -0.10569,-0.07081 V 25.80022 l 0.0919,-0.05285 v -0.0021 l -0.0919,-0.05285 v -0.237809 l 0.1226,-0.07081 h 0.26741 l 0.1226,0.07081 v 0.237809 l -0.0919,0.05285 v 0.0021 l 0.0919,0.05285 v 0.263176 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1688" />
+            <path
+               d="m 143.33412,26.007378 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324477 h 0.21667 v -0.17228 h -0.21667 z m 0.24203,0.451309 h -0.28431 l -0.10569,-0.07081 V 25.80022 l 0.0919,-0.05285 v -0.0021 l -0.0919,-0.05285 v -0.237809 l 0.1226,-0.07081 h 0.2674 l 0.12261,0.07081 v 0.237809 l -0.092,0.05285 v 0.0021 l 0.092,0.05285 v 0.263176 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1690" />
+            <path
+               d="m 141.49401,26.965637 v -0.212443 l -0.0751,0.04333 h -0.15642 l -0.12261,-0.07081 v -0.312851 l 0.12261,-0.07082 h 0.25683 l 0.12261,0.07082 v 0.608791 l -0.12261,0.07081 h -0.25683 l -0.12261,-0.07081 v -0.151141 h 0.14797 v 0.09512 z m 0,-0.295941 V 26.46888 h -0.20611 v 0.200816 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1692" />
+            <path
+               d="m 142.3554,27.021654 -0.1226,0.07081 h -0.28854 l -0.12261,-0.07081 v -0.608791 l 0.12261,-0.07082 h 0.28854 l 0.1226,0.07082 z m -0.38578,-0.552774 v 0.496757 h 0.23781 V 26.46888 Z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1694" />
+            <path
+               d="m 142.68305,26.965637 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324478 h 0.21667 V 26.46888 h -0.21667 z m 0.24204,0.451309 h -0.28432 l -0.10569,-0.07081 v -0.263175 l 0.0919,-0.05285 v -0.0021 l -0.0919,-0.05285 v -0.237809 l 0.1226,-0.07082 h 0.26741 l 0.1226,0.07082 v 0.237809 l -0.0919,0.05285 v 0.0021 l 0.0919,0.05285 v 0.263175 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1696" />
+            <path
+               d="m 143.67128,26.92336 v 0.163824 h -0.14586 V 26.92336 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13001 v 0.456594 h 0.0909 v 0.119433 z m -0.33294,-0.119433 h 0.18708 V 26.56506 h -0.002 l -0.18497,0.236753 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1698" />
+          </g>
         </g>
       </g>
     </g>
@@ -650,13 +614,10 @@
            id="g2802"
            transform="matrix(0.42823078,0,0,0.03588626,-82.349033,-6.213123)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2800"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <path
            id="path2804"
@@ -672,55 +633,52 @@
            id="g2810"
            transform="matrix(0.42775623,0,0,0.03588626,-40.261946,-6.213123)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2808"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <g
            id="g2814"
            transform="matrix(0.42823078,0,0,0.03588626,-82.349033,10.521363)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2812"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <g
            id="g2818"
            transform="matrix(0.42775623,0,0,0.03588626,-40.261946,10.521363)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2816"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
       </g>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:7.2603px;line-height:0;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.181509"
-         x="-517.23639"
-         y="45.075752"
-         id="text2838"><tspan
-           sodipodi:role="line"
-           x="-517.23639"
-           y="45.075752"
+      <g
+         aria-label="DAYS
+"
+         id="text2838"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:7.2603px;line-height:0;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.181509">
+        <path
+           d="m -512.6624,44.589312 -0.84219,0.48644 h -3.11467 v -5.08221 h 3.11467 l 0.84219,0.48644 z m -2.94042,-3.724534 v 3.339738 h 1.92398 v -3.339738 z"
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.181509"
-           id="tspan2834">DAYS</tspan><tspan
-           sodipodi:role="line"
-           x="-517.23639"
-           y="52.384285"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.76823px;line-height:0.4;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.181509"
-           id="tspan2836" /></text>
+           id="path1608" />
+        <path
+           d="m -509.07582,39.993542 1.81507,5.08221 h -1.00192 l -0.3848,-1.096305 h -1.9022 l -0.38479,1.096305 h -1.00192 l 1.81507,-5.08221 z m -0.53001,1.277813 -0.6389,1.836856 h 1.28507 l -0.63165,-1.836856 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.181509"
+           id="path1610" />
+        <path
+           d="m -505.845,45.075752 v -2.170829 l -1.63357,-2.911381 h 1.10357 l 1.03096,1.902199 h 0.0145 l 1.03822,-1.902199 h 1.10357 l -1.64083,2.918641 v 2.163569 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.181509"
+           id="path1612" />
+        <path
+           d="m -502.46171,42.498346 v -2.054665 l 0.84219,-0.48644 h 1.83686 l 0.84219,0.48644 v 0.96562 h -1.01644 v -0.580824 h -1.48836 v 1.21247 h 1.66261 l 0.84219,0.48644 v 2.098227 l -0.84219,0.48644 h -1.90946 l -0.8422,-0.48644 v -0.96562 h 1.01644 v 0.580824 h 1.56097 v -1.256032 h -1.66261 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.181509"
+           id="path1614" />
+      </g>
       <g
          id="g3042"
          transform="translate(-51.450429,37.041663)"
@@ -729,73 +687,82 @@
            id="g3030"
            style="opacity:0.736082;fill:#ffffff;fill-opacity:1"
            transform="matrix(-1.1061792,0,0,1.1061792,-624.48914,-29.465818)">
-          <rect
-             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3020"
-             width="2.7561522"
-             height="0.19935799"
-             x="141.00124"
-             y="27.404345"
-             transform="scale(-1,1)" />
-          <text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832"
-             x="141.05009"
-             y="26.128925"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             transform="scale(-1,1)"
+             d="m 141.00124,27.404345 h 2.75615 v 0.199358 h -2.75615 z" />
+          <g
+             aria-label="4010
+42G1
+"
+             transform="scale(-1,1)"
              id="text3028"
-             transform="scale(-1,1)"><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="26.128925"
+             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832">
+            <path
+               d="m 141.58384,25.965101 v 0.163824 h -0.14585 v -0.163824 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 v -0.238866 h -0.002 l -0.18496,0.236752 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3022">4010</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="27.087183"
+               id="path1618" />
+            <path
+               d="m 142.34589,26.063396 -0.1226,0.07081 h -0.28855 l -0.1226,-0.07081 v -0.608792 l 0.1226,-0.07081 h 0.28855 l 0.1226,0.07081 z m -0.38578,-0.552775 v 0.496757 h 0.23781 v -0.496757 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3024">42G1</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="28.045443"
+               id="path1620" />
+            <path
+               d="m 142.52557,25.636396 v -0.138458 l 0.19024,-0.108864 h 0.12684 v 0.61302 h 0.16911 v 0.126831 h -0.48619 v -0.126831 h 0.16911 v -0.462936 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3026" /></text>
+               id="path1622" />
+            <path
+               d="m 143.67234,26.063396 -0.12261,0.07081 h -0.28854 l -0.1226,-0.07081 v -0.608792 l 0.1226,-0.07081 h 0.28854 l 0.12261,0.07081 z m -0.38578,-0.552775 v 0.496757 h 0.23781 v -0.496757 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1624" />
+            <path
+               d="m 141.58384,26.92336 v 0.163824 h -0.14585 V 26.92336 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 V 26.56506 h -0.002 l -0.18496,0.236753 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1626" />
+            <path
+               d="m 141.96011,26.960352 h 0.34879 v 0.126832 h -0.49676 v -0.34773 l 0.1226,-0.07081 h 0.22619 v -0.194476 h -0.20082 v 0.09512 h -0.14797 v -0.151141 l 0.1226,-0.07081 h 0.25155 l 0.12261,0.07081 v 0.30651 l -0.12261,0.07081 h -0.22618 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1628" />
+            <path
+               d="m 142.75281,26.828236 v -0.126832 h 0.26951 v 0.32025 l -0.1226,0.07081 h -0.29911 l -0.1226,-0.07081 v -0.608791 l 0.1226,-0.07082 h 0.29911 l 0.1226,0.07082 v 0.15114 h -0.14797 v -0.09512 h -0.24837 v 0.496757 h 0.24837 v -0.137401 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1630" />
+            <path
+               d="m 143.19143,26.594654 v -0.138457 l 0.19025,-0.108864 h 0.12683 v 0.613019 h 0.16911 v 0.126832 h -0.48619 v -0.126832 h 0.16911 v -0.462935 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1632" />
+          </g>
         </g>
         <g
            id="g3040"
            style="opacity:0.736082;fill:#ffffff;fill-opacity:1"
            transform="matrix(-1.1061792,0,0,1.1061792,-584.67443,-19.57102)">
-          <text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832"
-             x="141.05009"
-             y="26.128925"
+          <g
+             aria-label="6
+4
+8
+8
+"
+             transform="scale(-1,1)"
              id="text3038"
-             transform="scale(-1,1)"><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="26.128925"
+             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832">
+            <path
+               d="m 141.2879,25.510621 v 0.212443 l 0.0751,-0.04333 h 0.15642 l 0.12261,0.07081 v 0.312852 l -0.12261,0.07081 h -0.25683 l -0.12261,-0.07081 v -0.608792 l 0.12261,-0.07081 h 0.25683 l 0.12261,0.07081 v 0.151141 h -0.14797 v -0.09512 z m 0,0.295941 v 0.200816 h 0.20611 v -0.200816 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3034">6</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="27.087183"
+               id="path1635" />
+            <path
+               d="m 141.58384,26.92336 v 0.163824 h -0.14585 V 26.92336 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 V 26.56506 h -0.002 l -0.18496,0.236753 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3391">4</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="28.045443"
+               id="path1637" />
+            <path
+               d="m 141.2879,27.923895 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324477 h 0.21667 v -0.17228 h -0.21667 z m 0.24204,0.451309 h -0.28431 l -0.1057,-0.07081 v -0.263176 l 0.092,-0.05285 v -0.0021 l -0.092,-0.05285 v -0.237809 l 0.12261,-0.07081 h 0.2674 l 0.1226,0.07081 v 0.237809 l -0.0919,0.05285 v 0.0021 l 0.0919,0.05285 v 0.263176 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3393">8</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="29.0037"
+               id="path1639" />
+            <path
+               d="m 141.2879,28.882154 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324478 h 0.21667 v -0.172279 h -0.21667 z m 0.24204,0.451309 h -0.28431 l -0.1057,-0.07081 v -0.263175 l 0.092,-0.05285 v -0.0021 l -0.092,-0.05285 v -0.23781 l 0.12261,-0.07081 h 0.2674 l 0.1226,0.07081 v 0.23781 l -0.0919,0.05285 v 0.0021 l 0.0919,0.05285 v 0.263175 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3395">8</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="29.96196"
-               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3036" /></text>
+               id="path1641" />
+          </g>
         </g>
       </g>
       <path
@@ -831,13 +798,10 @@
            id="g2706"
            transform="matrix(0.42823078,0,0,0.03588626,-82.349033,-6.213123)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2704"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <path
            id="path2708"
@@ -853,55 +817,72 @@
            id="g2714"
            transform="matrix(0.42775623,0,0,0.03588626,-40.261946,-6.213123)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2712"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <g
            id="g2718"
            transform="matrix(0.42823078,0,0,0.03588626,-82.349033,10.521363)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2716"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <g
            id="g2722"
            transform="matrix(0.42775623,0,0,0.03588626,-40.261946,10.521363)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect2720"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
       </g>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:6.79812px;line-height:0;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.169954"
-         x="-500.95551"
-         y="7.8723207"
-         id="text2742"><tspan
-           sodipodi:role="line"
-           x="-500.95551"
-           y="7.8723207"
+      <g
+         aria-label="CONTAINER
+"
+         id="text2742"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:6.79812px;line-height:0;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.169954">
+        <path
+           d="m -516.84948,6.478706 h 0.95174 v 0.9721312 l -0.78858,0.4554741 h -1.92387 l -0.78858,-0.4554741 V 3.5351201 l 0.78858,-0.4554741 h 1.92387 l 0.78858,0.4554741 v 0.9721311 h -0.95174 V 3.8954204 h -1.59756 v 3.1951164 h 1.59756 z"
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
-           id="tspan2738">CONTAINER</tspan><tspan
-           sodipodi:role="line"
-           x="-500.95551"
-           y="14.715603"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.592px;line-height:0.4;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
-           id="tspan2740" /></text>
+           id="path1549" />
+        <path
+           d="m -511.10507,7.4508372 -0.78859,0.4554741 h -2.12781 l -0.78858,-0.4554741 V 3.5351201 l 0.78858,-0.4554741 h 2.12781 l 0.78859,0.4554741 z m -2.75324,-3.5554168 v 3.1951164 h 1.8015 V 3.8954204 Z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1551" />
+        <path
+           d="m -508.99767,4.7927723 v 3.0795484 h -0.95174 V 3.1136366 h 0.89056 l 2.05303,3.0795484 h 0.0136 V 3.1136366 h 0.95173 v 4.7586841 h -0.89055 l -2.05303,-3.0795484 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1553" />
+        <path
+           d="m -503.05612,3.929411 v 3.9429097 h -0.95174 V 3.929411 h -1.28484 V 3.1136366 h 3.52143 V 3.929411 Z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1555" />
+        <path
+           d="m -499.16081,3.1136366 1.69953,4.7586841 h -0.93814 l -0.3603,-1.0265162 h -1.78111 l -0.3603,1.0265162 h -0.93814 l 1.69953,-4.7586841 z m -0.49626,1.1964692 -0.59824,1.7199243 h 1.20327 l -0.59144,-1.7199243 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1557" />
+        <path
+           d="M -496.78147,7.8723207 V 3.1136366 h 0.95174 v 4.7586841 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1559" />
+        <path
+           d="m -493.72232,4.7927723 v 3.0795484 h -0.95174 V 3.1136366 h 0.89056 l 2.05303,3.0795484 h 0.0136 V 3.1136366 h 0.95173 v 4.7586841 h -0.89055 l -2.05303,-3.0795484 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1561" />
+        <path
+           d="m -488.65773,5.8328846 v 1.2236616 h 1.89668 v 0.8157745 h -2.84841 V 3.1136366 h 2.84841 V 3.929411 h -1.89668 v 1.0876992 h 1.48879 v 0.8157744 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1563" />
+        <path
+           d="m -482.2675,7.8723207 h -1.04691 l -1.01971,-1.7947037 h -0.59144 v 1.7947037 h -0.95174 V 3.1136366 h 2.57649 l 0.78858,0.4554741 v 2.0530322 l -0.78858,0.4554741 z m -2.65806,-3.9429097 v 1.3324316 h 1.46159 V 3.929411 Z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1565" />
+      </g>
       <g
          id="g3066"
          style="opacity:0.61011"
@@ -910,66 +891,100 @@
            id="g3054"
            style="opacity:0.736082;fill:#ffffff;fill-opacity:1"
            transform="matrix(-1.1061792,0,0,1.1061792,-624.48914,-29.465818)">
-          <rect
-             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3044"
-             width="2.7561522"
-             height="0.19935799"
-             x="141.00124"
-             y="27.404345"
-             transform="scale(-1,1)" />
-          <text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832"
-             x="141.05009"
-             y="26.128925"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             transform="scale(-1,1)"
+             d="m 141.00124,27.404345 h 2.75615 v 0.199358 h -2.75615 z" />
+          <g
+             aria-label="4010
+42G1
+"
+             transform="scale(-1,1)"
              id="text3052"
-             transform="scale(-1,1)"><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="26.128925"
+             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832">
+            <path
+               d="m 141.58384,25.965101 v 0.163824 h -0.14585 v -0.163824 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 v -0.238866 h -0.002 l -0.18496,0.236752 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3046">4010</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="27.087183"
+               id="path1569" />
+            <path
+               d="m 142.34589,26.063396 -0.1226,0.07081 h -0.28855 l -0.1226,-0.07081 v -0.608792 l 0.1226,-0.07081 h 0.28855 l 0.1226,0.07081 z m -0.38578,-0.552775 v 0.496757 h 0.23781 v -0.496757 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3048">42G1</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="28.045443"
+               id="path1571" />
+            <path
+               d="m 142.52557,25.636396 v -0.138458 l 0.19024,-0.108864 h 0.12684 v 0.61302 h 0.16911 v 0.126831 h -0.48619 v -0.126831 h 0.16911 v -0.462936 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3050" /></text>
+               id="path1573" />
+            <path
+               d="m 143.67234,26.063396 -0.12261,0.07081 h -0.28854 l -0.1226,-0.07081 v -0.608792 l 0.1226,-0.07081 h 0.28854 l 0.12261,0.07081 z m -0.38578,-0.552775 v 0.496757 h 0.23781 v -0.496757 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1575" />
+            <path
+               d="m 141.58384,26.92336 v 0.163824 h -0.14585 V 26.92336 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 V 26.56506 h -0.002 l -0.18496,0.236753 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1577" />
+            <path
+               d="m 141.96011,26.960352 h 0.34879 v 0.126832 h -0.49676 v -0.34773 l 0.1226,-0.07081 h 0.22619 v -0.194476 h -0.20082 v 0.09512 h -0.14797 v -0.151141 l 0.1226,-0.07081 h 0.25155 l 0.12261,0.07081 v 0.30651 l -0.12261,0.07081 h -0.22618 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1579" />
+            <path
+               d="m 142.75281,26.828236 v -0.126832 h 0.26951 v 0.32025 l -0.1226,0.07081 h -0.29911 l -0.1226,-0.07081 v -0.608791 l 0.1226,-0.07082 h 0.29911 l 0.1226,0.07082 v 0.15114 h -0.14797 v -0.09512 h -0.24837 v 0.496757 h 0.24837 v -0.137401 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1581" />
+            <path
+               d="m 143.19143,26.594654 v -0.138457 l 0.19025,-0.108864 h 0.12683 v 0.613019 h 0.16911 v 0.126832 h -0.48619 v -0.126832 h 0.16911 v -0.462935 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1583" />
+          </g>
         </g>
         <g
            id="g3064"
            style="opacity:0.736082;fill:#ffffff;fill-opacity:1"
            transform="matrix(-1.1061792,0,0,1.1061792,-589.15206,-17.983519)">
-          <rect
-             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3056"
-             width="2.7561522"
-             height="0.19935799"
-             x="141.00124"
-             y="27.404345"
-             transform="scale(-1,1)" />
-          <text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832"
-             x="141.05009"
-             y="26.128925"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             transform="scale(-1,1)"
+             d="m 141.00124,27.404345 h 2.75615 v 0.199358 h -2.75615 z" />
+          <g
+             aria-label="6488
+9084"
+             transform="scale(-1,1)"
              id="text3062"
-             transform="scale(-1,1)"><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="26.128925"
+             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832">
+            <path
+               d="m 141.2879,25.510621 v 0.212443 l 0.0751,-0.04333 h 0.15642 l 0.12261,0.07081 v 0.312852 l -0.12261,0.07081 h -0.25683 l -0.12261,-0.07081 v -0.608792 l 0.12261,-0.07081 h 0.25683 l 0.12261,0.07081 v 0.151141 h -0.14797 v -0.09512 z m 0,0.295941 v 0.200816 h 0.20611 v -0.200816 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3058">6488</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="27.087183"
+               id="path1587" />
+            <path
+               d="m 142.26556,25.965101 v 0.163824 h -0.14585 v -0.163824 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 v -0.238866 h -0.002 l -0.18496,0.236752 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3060">9084</tspan></text>
+               id="path1589" />
+            <path
+               d="m 142.64183,26.007378 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324477 h 0.21667 v -0.17228 h -0.21667 z m 0.24204,0.451309 h -0.28432 l -0.10569,-0.07081 V 25.80022 l 0.0919,-0.05285 v -0.0021 l -0.0919,-0.05285 v -0.237809 l 0.1226,-0.07081 h 0.26741 l 0.1226,0.07081 v 0.237809 l -0.0919,0.05285 v 0.0021 l 0.0919,0.05285 v 0.263176 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1591" />
+            <path
+               d="m 143.33412,26.007378 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324477 h 0.21667 v -0.17228 h -0.21667 z m 0.24203,0.451309 h -0.28431 l -0.10569,-0.07081 V 25.80022 l 0.0919,-0.05285 v -0.0021 l -0.0919,-0.05285 v -0.237809 l 0.1226,-0.07081 h 0.2674 l 0.12261,0.07081 v 0.237809 l -0.092,0.05285 v 0.0021 l 0.092,0.05285 v 0.263176 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1593" />
+            <path
+               d="m 141.49401,26.965637 v -0.212443 l -0.0751,0.04333 h -0.15642 l -0.12261,-0.07081 v -0.312851 l 0.12261,-0.07082 h 0.25683 l 0.12261,0.07082 v 0.608791 l -0.12261,0.07081 h -0.25683 l -0.12261,-0.07081 v -0.151141 h 0.14797 v 0.09512 z m 0,-0.295941 V 26.46888 h -0.20611 v 0.200816 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1595" />
+            <path
+               d="m 142.3554,27.021654 -0.1226,0.07081 h -0.28854 l -0.12261,-0.07081 v -0.608791 l 0.12261,-0.07082 h 0.28854 l 0.1226,0.07082 z m -0.38578,-0.552774 v 0.496757 h 0.23781 V 26.46888 Z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1597" />
+            <path
+               d="m 142.68305,26.965637 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324478 h 0.21667 V 26.46888 h -0.21667 z m 0.24204,0.451309 h -0.28432 l -0.10569,-0.07081 v -0.263175 l 0.0919,-0.05285 v -0.0021 l -0.0919,-0.05285 v -0.237809 l 0.1226,-0.07082 h 0.26741 l 0.1226,0.07082 v 0.237809 l -0.0919,0.05285 v 0.0021 l 0.0919,0.05285 v 0.263175 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1599" />
+            <path
+               d="m 143.67128,26.92336 v 0.163824 h -0.14586 V 26.92336 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13001 v 0.456594 h 0.0909 v 0.119433 z m -0.33294,-0.119433 h 0.18708 V 26.56506 h -0.002 l -0.18497,0.236753 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1601" />
+          </g>
         </g>
       </g>
     </g>
@@ -1001,13 +1016,10 @@
            id="g3833"
            transform="matrix(0.42823078,0,0,0.03588626,-82.349033,-6.213123)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3831"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <path
            id="path3835"
@@ -1023,55 +1035,68 @@
            id="g3841"
            transform="matrix(0.42775623,0,0,0.03588626,-40.261946,-6.213123)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3839"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <g
            id="g3845"
            transform="matrix(0.42823078,0,0,0.03588626,-82.349033,10.521363)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3843"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <g
            id="g3849"
            transform="matrix(0.42775623,0,0,0.03588626,-40.261946,10.521363)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3847"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
       </g>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:7.41456px;line-height:0;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.185365"
-         x="-500.95859"
-         y="26.60891"
-         id="text3857"><tspan
-           sodipodi:role="line"
-           x="-500.95859"
-           y="26.60891"
+      <g
+         aria-label="PLUMBING
+"
+         id="text3857"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:7.41456px;line-height:0;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.185365">
+        <path
+           d="m -519.2651,26.60891 v -5.190192 h 2.73597 l 0.86009,0.496775 v 2.313343 l -0.86009,0.496775 h -1.69793 v 1.883299 z m 1.03804,-4.300445 v 1.527399 h 1.51998 v -1.527399 z"
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
-           id="tspan3853">PLUMBING</tspan><tspan
-           sodipodi:role="line"
-           x="-500.95859"
-           y="34.072727"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.82704px;line-height:0.4;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
-           id="tspan3855" /></text>
+           id="path1492" />
+        <path
+           d="m -514.63101,26.60891 v -5.190192 h 1.03803 v 4.300444 h 1.77208 v 0.889748 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1494" />
+        <path
+           d="m -508.00241,21.418718 h 1.03804 v 4.730489 l -0.86009,0.496775 h -2.32076 l -0.86009,-0.496775 v -4.730489 h 1.03804 v 4.263372 h 1.96486 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1496" />
+        <path
+           d="m -501.33673,26.60891 v -3.425527 h -0.0148 l -1.1715,3.425527 h -0.98614 l -1.17891,-3.470014 h -0.0148 v 3.470014 h -1.00097 v -5.190192 h 1.37911 l 1.30496,3.818498 h 0.0148 l 1.29755,-3.818498 h 1.37169 v 5.190192 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1498" />
+        <path
+           d="m -495.40509,23.546696 -0.64507,0.370728 v 0.01483 l 0.64507,0.370727 v 1.809153 l -0.86009,0.496776 h -2.81012 v -5.190192 h 2.81012 l 0.86009,0.496775 z m -2.63217,0.823017 v 1.349449 h 1.59413 v -1.349449 z m 0,-2.061248 v 1.1715 h 1.59413 v -1.1715 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1500" />
+        <path
+           d="m -494.14462,26.60891 v -5.190192 h 1.03803 v 5.190192 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1502" />
+        <path
+           d="m -490.80808,23.250114 v 3.358796 h -1.03803 v -5.190192 h 0.9713 l 2.2392,3.358795 h 0.0148 v -3.358795 h 1.03804 v 5.190192 h -0.97131 l -2.2392,-3.358796 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1504" />
+        <path
+           d="m -484.46863,24.792342 v -0.889747 h 1.89071 v 2.246612 l -0.86009,0.496775 h -2.09832 l -0.86009,-0.496775 V 21.87842 l 0.86009,-0.496775 h 2.09832 l 0.86009,0.496775 v 1.060282 h -1.03804 v -0.66731 h -1.74242 v 3.484843 h 1.74242 v -0.963893 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.185365"
+           id="path1506" />
+      </g>
       <g
          id="g3881"
          transform="translate(-51.450429,18.520832)"
@@ -1080,66 +1105,100 @@
            id="g3869"
            style="opacity:0.736082;fill:#ffffff;fill-opacity:1"
            transform="matrix(-1.1061792,0,0,1.1061792,-624.48914,-29.465818)">
-          <rect
-             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3859"
-             width="2.7561522"
-             height="0.19935799"
-             x="141.00124"
-             y="27.404345"
-             transform="scale(-1,1)" />
-          <text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832"
-             x="141.05009"
-             y="26.128925"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             transform="scale(-1,1)"
+             d="m 141.00124,27.404345 h 2.75615 v 0.199358 h -2.75615 z" />
+          <g
+             aria-label="4010
+42G1
+"
+             transform="scale(-1,1)"
              id="text3867"
-             transform="scale(-1,1)"><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="26.128925"
+             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832">
+            <path
+               d="m 141.58384,25.965101 v 0.163824 h -0.14585 v -0.163824 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 v -0.238866 h -0.002 l -0.18496,0.236752 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3861">4010</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="27.087183"
+               id="path1510" />
+            <path
+               d="m 142.34589,26.063396 -0.1226,0.07081 h -0.28855 l -0.1226,-0.07081 v -0.608792 l 0.1226,-0.07081 h 0.28855 l 0.1226,0.07081 z m -0.38578,-0.552775 v 0.496757 h 0.23781 v -0.496757 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3863">42G1</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="28.045443"
+               id="path1512" />
+            <path
+               d="m 142.52557,25.636396 v -0.138458 l 0.19024,-0.108864 h 0.12684 v 0.61302 h 0.16911 v 0.126831 h -0.48619 v -0.126831 h 0.16911 v -0.462936 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3865" /></text>
+               id="path1514" />
+            <path
+               d="m 143.67234,26.063396 -0.12261,0.07081 h -0.28854 l -0.1226,-0.07081 v -0.608792 l 0.1226,-0.07081 h 0.28854 l 0.12261,0.07081 z m -0.38578,-0.552775 v 0.496757 h 0.23781 v -0.496757 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1516" />
+            <path
+               d="m 141.58384,26.92336 v 0.163824 h -0.14585 V 26.92336 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 V 26.56506 h -0.002 l -0.18496,0.236753 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1518" />
+            <path
+               d="m 141.96011,26.960352 h 0.34879 v 0.126832 h -0.49676 v -0.34773 l 0.1226,-0.07081 h 0.22619 v -0.194476 h -0.20082 v 0.09512 h -0.14797 v -0.151141 l 0.1226,-0.07081 h 0.25155 l 0.12261,0.07081 v 0.30651 l -0.12261,0.07081 h -0.22618 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1520" />
+            <path
+               d="m 142.75281,26.828236 v -0.126832 h 0.26951 v 0.32025 l -0.1226,0.07081 h -0.29911 l -0.1226,-0.07081 v -0.608791 l 0.1226,-0.07082 h 0.29911 l 0.1226,0.07082 v 0.15114 h -0.14797 v -0.09512 h -0.24837 v 0.496757 h 0.24837 v -0.137401 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1522" />
+            <path
+               d="m 143.19143,26.594654 v -0.138457 l 0.19025,-0.108864 h 0.12683 v 0.613019 h 0.16911 v 0.126832 h -0.48619 v -0.126832 h 0.16911 v -0.462935 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1524" />
+          </g>
         </g>
         <g
            id="g3879"
            style="opacity:0.736082;fill:#ffffff;fill-opacity:1"
            transform="matrix(-1.1061792,0,0,1.1061792,-589.15206,-17.983519)">
-          <rect
-             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3871"
-             width="2.7561522"
-             height="0.19935799"
-             x="141.00124"
-             y="27.404345"
-             transform="scale(-1,1)" />
-          <text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832"
-             x="141.05009"
-             y="26.128925"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             transform="scale(-1,1)"
+             d="m 141.00124,27.404345 h 2.75615 v 0.199358 h -2.75615 z" />
+          <g
+             aria-label="6488
+9084"
+             transform="scale(-1,1)"
              id="text3877"
-             transform="scale(-1,1)"><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="26.128925"
+             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832">
+            <path
+               d="m 141.2879,25.510621 v 0.212443 l 0.0751,-0.04333 h 0.15642 l 0.12261,0.07081 v 0.312852 l -0.12261,0.07081 h -0.25683 l -0.12261,-0.07081 v -0.608792 l 0.12261,-0.07081 h 0.25683 l 0.12261,0.07081 v 0.151141 h -0.14797 v -0.09512 z m 0,0.295941 v 0.200816 h 0.20611 v -0.200816 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3873">6488</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="27.087183"
+               id="path1528" />
+            <path
+               d="m 142.26556,25.965101 v 0.163824 h -0.14585 v -0.163824 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 v -0.238866 h -0.002 l -0.18496,0.236752 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3875">9084</tspan></text>
+               id="path1530" />
+            <path
+               d="m 142.64183,26.007378 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324477 h 0.21667 v -0.17228 h -0.21667 z m 0.24204,0.451309 h -0.28432 l -0.10569,-0.07081 V 25.80022 l 0.0919,-0.05285 v -0.0021 l -0.0919,-0.05285 v -0.237809 l 0.1226,-0.07081 h 0.26741 l 0.1226,0.07081 v 0.237809 l -0.0919,0.05285 v 0.0021 l 0.0919,0.05285 v 0.263176 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1532" />
+            <path
+               d="m 143.33412,26.007378 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324477 h 0.21667 v -0.17228 h -0.21667 z m 0.24203,0.451309 h -0.28431 l -0.10569,-0.07081 V 25.80022 l 0.0919,-0.05285 v -0.0021 l -0.0919,-0.05285 v -0.237809 l 0.1226,-0.07081 h 0.2674 l 0.12261,0.07081 v 0.237809 l -0.092,0.05285 v 0.0021 l 0.092,0.05285 v 0.263176 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1534" />
+            <path
+               d="m 141.49401,26.965637 v -0.212443 l -0.0751,0.04333 h -0.15642 l -0.12261,-0.07081 v -0.312851 l 0.12261,-0.07082 h 0.25683 l 0.12261,0.07082 v 0.608791 l -0.12261,0.07081 h -0.25683 l -0.12261,-0.07081 v -0.151141 h 0.14797 v 0.09512 z m 0,-0.295941 V 26.46888 h -0.20611 v 0.200816 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1536" />
+            <path
+               d="m 142.3554,27.021654 -0.1226,0.07081 h -0.28854 l -0.12261,-0.07081 v -0.608791 l 0.12261,-0.07082 h 0.28854 l 0.1226,0.07082 z m -0.38578,-0.552774 v 0.496757 h 0.23781 V 26.46888 Z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1538" />
+            <path
+               d="m 142.68305,26.965637 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324478 h 0.21667 V 26.46888 h -0.21667 z m 0.24204,0.451309 h -0.28432 l -0.10569,-0.07081 v -0.263175 l 0.0919,-0.05285 v -0.0021 l -0.0919,-0.05285 v -0.237809 l 0.1226,-0.07082 h 0.26741 l 0.1226,0.07082 v 0.237809 l -0.0919,0.05285 v 0.0021 l 0.0919,0.05285 v 0.263175 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1540" />
+            <path
+               d="m 143.67128,26.92336 v 0.163824 h -0.14586 V 26.92336 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13001 v 0.456594 h 0.0909 v 0.119433 z m -0.33294,-0.119433 h 0.18708 V 26.56506 h -0.002 l -0.18497,0.236753 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1542" />
+          </g>
         </g>
       </g>
     </g>
@@ -1171,13 +1230,10 @@
            id="g3895"
            transform="matrix(0.42823078,0,0,0.03588626,-82.349033,-6.213123)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3893"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <path
            id="path3897"
@@ -1193,55 +1249,52 @@
            id="g3903"
            transform="matrix(0.42775623,0,0,0.03588626,-40.261946,-6.213123)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3901"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <g
            id="g3907"
            transform="matrix(0.42823078,0,0,0.03588626,-82.349033,10.521363)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3905"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <g
            id="g3911"
            transform="matrix(0.42775623,0,0,0.03588626,-40.261946,10.521363)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3909"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
       </g>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:7.2603px;line-height:0;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.181509"
-         x="-517.23639"
-         y="45.075752"
-         id="text3919"><tspan
-           sodipodi:role="line"
-           x="-517.23639"
-           y="45.075752"
+      <g
+         aria-label="DAYS
+"
+         id="text3919"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:7.2603px;line-height:0;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.181509">
+        <path
+           d="m -512.6624,44.589312 -0.84219,0.48644 h -3.11467 v -5.08221 h 3.11467 l 0.84219,0.48644 z m -2.94042,-3.724534 v 3.339738 h 1.92398 v -3.339738 z"
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.181509"
-           id="tspan3915">DAYS</tspan><tspan
-           sodipodi:role="line"
-           x="-517.23639"
-           y="52.384285"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.76823px;line-height:0.4;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.181509"
-           id="tspan3917" /></text>
+           id="path1452" />
+        <path
+           d="m -509.07582,39.993542 1.81507,5.08221 h -1.00192 l -0.3848,-1.096305 h -1.9022 l -0.38479,1.096305 h -1.00192 l 1.81507,-5.08221 z m -0.53001,1.277813 -0.6389,1.836856 h 1.28507 l -0.63165,-1.836856 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.181509"
+           id="path1454" />
+        <path
+           d="m -505.845,45.075752 v -2.170829 l -1.63357,-2.911381 h 1.10357 l 1.03096,1.902199 h 0.0145 l 1.03822,-1.902199 h 1.10357 l -1.64083,2.918641 v 2.163569 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.181509"
+           id="path1456" />
+        <path
+           d="m -502.46171,42.498346 v -2.054665 l 0.84219,-0.48644 h 1.83686 l 0.84219,0.48644 v 0.96562 h -1.01644 v -0.580824 h -1.48836 v 1.21247 h 1.66261 l 0.84219,0.48644 v 2.098227 l -0.84219,0.48644 h -1.90946 l -0.8422,-0.48644 v -0.96562 h 1.01644 v 0.580824 h 1.56097 v -1.256032 h -1.66261 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.181509"
+           id="path1458" />
+      </g>
       <g
          id="g3947"
          transform="translate(-51.450429,37.041663)"
@@ -1250,73 +1303,82 @@
            id="g3931"
            style="opacity:0.736082;fill:#ffffff;fill-opacity:1"
            transform="matrix(-1.1061792,0,0,1.1061792,-624.48914,-29.465818)">
-          <rect
-             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3921"
-             width="2.7561522"
-             height="0.19935799"
-             x="141.00124"
-             y="27.404345"
-             transform="scale(-1,1)" />
-          <text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832"
-             x="141.05009"
-             y="26.128925"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             transform="scale(-1,1)"
+             d="m 141.00124,27.404345 h 2.75615 v 0.199358 h -2.75615 z" />
+          <g
+             aria-label="4010
+42G1
+"
+             transform="scale(-1,1)"
              id="text3929"
-             transform="scale(-1,1)"><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="26.128925"
+             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832">
+            <path
+               d="m 141.58384,25.965101 v 0.163824 h -0.14585 v -0.163824 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 v -0.238866 h -0.002 l -0.18496,0.236752 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3923">4010</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="27.087183"
+               id="path1462" />
+            <path
+               d="m 142.34589,26.063396 -0.1226,0.07081 h -0.28855 l -0.1226,-0.07081 v -0.608792 l 0.1226,-0.07081 h 0.28855 l 0.1226,0.07081 z m -0.38578,-0.552775 v 0.496757 h 0.23781 v -0.496757 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3925">42G1</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="28.045443"
+               id="path1464" />
+            <path
+               d="m 142.52557,25.636396 v -0.138458 l 0.19024,-0.108864 h 0.12684 v 0.61302 h 0.16911 v 0.126831 h -0.48619 v -0.126831 h 0.16911 v -0.462936 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3927" /></text>
+               id="path1466" />
+            <path
+               d="m 143.67234,26.063396 -0.12261,0.07081 h -0.28854 l -0.1226,-0.07081 v -0.608792 l 0.1226,-0.07081 h 0.28854 l 0.12261,0.07081 z m -0.38578,-0.552775 v 0.496757 h 0.23781 v -0.496757 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1468" />
+            <path
+               d="m 141.58384,26.92336 v 0.163824 h -0.14585 V 26.92336 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 V 26.56506 h -0.002 l -0.18496,0.236753 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1470" />
+            <path
+               d="m 141.96011,26.960352 h 0.34879 v 0.126832 h -0.49676 v -0.34773 l 0.1226,-0.07081 h 0.22619 v -0.194476 h -0.20082 v 0.09512 h -0.14797 v -0.151141 l 0.1226,-0.07081 h 0.25155 l 0.12261,0.07081 v 0.30651 l -0.12261,0.07081 h -0.22618 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1472" />
+            <path
+               d="m 142.75281,26.828236 v -0.126832 h 0.26951 v 0.32025 l -0.1226,0.07081 h -0.29911 l -0.1226,-0.07081 v -0.608791 l 0.1226,-0.07082 h 0.29911 l 0.1226,0.07082 v 0.15114 h -0.14797 v -0.09512 h -0.24837 v 0.496757 h 0.24837 v -0.137401 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1474" />
+            <path
+               d="m 143.19143,26.594654 v -0.138457 l 0.19025,-0.108864 h 0.12683 v 0.613019 h 0.16911 v 0.126832 h -0.48619 v -0.126832 h 0.16911 v -0.462935 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1476" />
+          </g>
         </g>
         <g
            id="g3945"
            style="opacity:0.736082;fill:#ffffff;fill-opacity:1"
            transform="matrix(-1.1061792,0,0,1.1061792,-584.67443,-19.57102)">
-          <text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832"
-             x="141.05009"
-             y="26.128925"
+          <g
+             aria-label="6
+4
+8
+8
+"
+             transform="scale(-1,1)"
              id="text3943"
-             transform="scale(-1,1)"><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="26.128925"
+             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832">
+            <path
+               d="m 141.2879,25.510621 v 0.212443 l 0.0751,-0.04333 h 0.15642 l 0.12261,0.07081 v 0.312852 l -0.12261,0.07081 h -0.25683 l -0.12261,-0.07081 v -0.608792 l 0.12261,-0.07081 h 0.25683 l 0.12261,0.07081 v 0.151141 h -0.14797 v -0.09512 z m 0,0.295941 v 0.200816 h 0.20611 v -0.200816 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3933">6</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="27.087183"
+               id="path1479" />
+            <path
+               d="m 141.58384,26.92336 v 0.163824 h -0.14585 V 26.92336 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 V 26.56506 h -0.002 l -0.18496,0.236753 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3935">4</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="28.045443"
+               id="path1481" />
+            <path
+               d="m 141.2879,27.923895 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324477 h 0.21667 v -0.17228 h -0.21667 z m 0.24204,0.451309 h -0.28431 l -0.1057,-0.07081 v -0.263176 l 0.092,-0.05285 v -0.0021 l -0.092,-0.05285 v -0.237809 l 0.12261,-0.07081 h 0.2674 l 0.1226,0.07081 v 0.237809 l -0.0919,0.05285 v 0.0021 l 0.0919,0.05285 v 0.263176 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3937">8</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="29.0037"
+               id="path1483" />
+            <path
+               d="m 141.2879,28.882154 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324478 h 0.21667 v -0.172279 h -0.21667 z m 0.24204,0.451309 h -0.28431 l -0.1057,-0.07081 v -0.263175 l 0.092,-0.05285 v -0.0021 l -0.092,-0.05285 v -0.23781 l 0.12261,-0.07081 h 0.2674 l 0.1226,0.07081 v 0.23781 l -0.0919,0.05285 v 0.0021 l 0.0919,0.05285 v 0.263175 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3939">8</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="29.96196"
-               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3941" /></text>
+               id="path1485" />
+          </g>
         </g>
       </g>
       <path
@@ -1347,13 +1409,10 @@
            id="g3963"
            transform="matrix(0.42823078,0,0,0.03588626,-82.349033,-6.213123)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3961"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <path
            id="path3965"
@@ -1369,55 +1428,72 @@
            id="g3971"
            transform="matrix(0.42775623,0,0,0.03588626,-40.261946,-6.213123)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3969"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <g
            id="g3975"
            transform="matrix(0.42823078,0,0,0.03588626,-82.349033,10.521363)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3973"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
         <g
            id="g3979"
            transform="matrix(0.42775623,0,0,0.03588626,-40.261946,10.521363)"
            style="fill:#3d3846">
-          <rect
-             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3977"
-             width="1.5993923"
-             height="18.335726"
-             x="-153.79713"
-             y="-23.363579" />
+             style="fill:#3d3846;stroke:none;stroke-width:0.200858;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             d="m -153.79713,-23.363579 h 1.59939 v 18.335726 h -1.59939 z" />
         </g>
       </g>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:6.79812px;line-height:0;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.169954"
-         x="-500.95551"
-         y="7.8723207"
-         id="text3987"><tspan
-           sodipodi:role="line"
-           x="-500.95551"
-           y="7.8723207"
+      <g
+         aria-label="CONTAINER
+"
+         id="text3987"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:6.79812px;line-height:0;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.169954">
+        <path
+           d="m -516.84948,6.478706 h 0.95174 v 0.9721312 l -0.78858,0.4554741 h -1.92387 l -0.78858,-0.4554741 V 3.5351201 l 0.78858,-0.4554741 h 1.92387 l 0.78858,0.4554741 v 0.9721311 h -0.95174 V 3.8954204 h -1.59756 v 3.1951164 h 1.59756 z"
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
-           id="tspan3983">CONTAINER</tspan><tspan
-           sodipodi:role="line"
-           x="-500.95551"
-           y="14.715603"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:2.592px;line-height:0.4;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
-           id="tspan3985" /></text>
+           id="path1393" />
+        <path
+           d="m -511.10507,7.4508372 -0.78859,0.4554741 h -2.12781 l -0.78858,-0.4554741 V 3.5351201 l 0.78858,-0.4554741 h 2.12781 l 0.78859,0.4554741 z m -2.75324,-3.5554168 v 3.1951164 h 1.8015 V 3.8954204 Z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1395" />
+        <path
+           d="m -508.99767,4.7927723 v 3.0795484 h -0.95174 V 3.1136366 h 0.89056 l 2.05303,3.0795484 h 0.0136 V 3.1136366 h 0.95173 v 4.7586841 h -0.89055 l -2.05303,-3.0795484 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1397" />
+        <path
+           d="m -503.05612,3.929411 v 3.9429097 h -0.95174 V 3.929411 h -1.28484 V 3.1136366 h 3.52143 V 3.929411 Z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1399" />
+        <path
+           d="m -499.16081,3.1136366 1.69953,4.7586841 h -0.93814 l -0.3603,-1.0265162 h -1.78111 l -0.3603,1.0265162 h -0.93814 l 1.69953,-4.7586841 z m -0.49626,1.1964692 -0.59824,1.7199243 h 1.20327 l -0.59144,-1.7199243 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1401" />
+        <path
+           d="M -496.78147,7.8723207 V 3.1136366 h 0.95174 v 4.7586841 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1403" />
+        <path
+           d="m -493.72232,4.7927723 v 3.0795484 h -0.95174 V 3.1136366 h 0.89056 l 2.05303,3.0795484 h 0.0136 V 3.1136366 h 0.95173 v 4.7586841 h -0.89055 l -2.05303,-3.0795484 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1405" />
+        <path
+           d="m -488.65773,5.8328846 v 1.2236616 h 1.89668 v 0.8157745 h -2.84841 V 3.1136366 h 2.84841 V 3.929411 h -1.89668 v 1.0876992 h 1.48879 v 0.8157744 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1407" />
+        <path
+           d="m -482.2675,7.8723207 h -1.04691 l -1.01971,-1.7947037 h -0.59144 v 1.7947037 h -0.95174 V 3.1136366 h 2.57649 l 0.78858,0.4554741 v 2.0530322 l -0.78858,0.4554741 z m -2.65806,-3.9429097 v 1.3324316 h 1.46159 V 3.929411 Z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:2;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.169954"
+           id="path1409" />
+      </g>
       <g
          id="g4011"
          style="opacity:0.61011"
@@ -1426,66 +1502,100 @@
            id="g3999"
            style="opacity:0.736082;fill:#ffffff;fill-opacity:1"
            transform="matrix(-1.1061792,0,0,1.1061792,-624.48914,-29.465818)">
-          <rect
-             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect3989"
-             width="2.7561522"
-             height="0.19935799"
-             x="141.00124"
-             y="27.404345"
-             transform="scale(-1,1)" />
-          <text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832"
-             x="141.05009"
-             y="26.128925"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             transform="scale(-1,1)"
+             d="m 141.00124,27.404345 h 2.75615 v 0.199358 h -2.75615 z" />
+          <g
+             aria-label="4010
+42G1
+"
+             transform="scale(-1,1)"
              id="text3997"
-             transform="scale(-1,1)"><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="26.128925"
+             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832">
+            <path
+               d="m 141.58384,25.965101 v 0.163824 h -0.14585 v -0.163824 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 v -0.238866 h -0.002 l -0.18496,0.236752 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3991">4010</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="27.087183"
+               id="path1413" />
+            <path
+               d="m 142.34589,26.063396 -0.1226,0.07081 h -0.28855 l -0.1226,-0.07081 v -0.608792 l 0.1226,-0.07081 h 0.28855 l 0.1226,0.07081 z m -0.38578,-0.552775 v 0.496757 h 0.23781 v -0.496757 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3993">42G1</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="28.045443"
+               id="path1415" />
+            <path
+               d="m 142.52557,25.636396 v -0.138458 l 0.19024,-0.108864 h 0.12684 v 0.61302 h 0.16911 v 0.126831 h -0.48619 v -0.126831 h 0.16911 v -0.462936 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan3995" /></text>
+               id="path1417" />
+            <path
+               d="m 143.67234,26.063396 -0.12261,0.07081 h -0.28854 l -0.1226,-0.07081 v -0.608792 l 0.1226,-0.07081 h 0.28854 l 0.12261,0.07081 z m -0.38578,-0.552775 v 0.496757 h 0.23781 v -0.496757 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1419" />
+            <path
+               d="m 141.58384,26.92336 v 0.163824 h -0.14585 V 26.92336 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 V 26.56506 h -0.002 l -0.18496,0.236753 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1421" />
+            <path
+               d="m 141.96011,26.960352 h 0.34879 v 0.126832 h -0.49676 v -0.34773 l 0.1226,-0.07081 h 0.22619 v -0.194476 h -0.20082 v 0.09512 h -0.14797 v -0.151141 l 0.1226,-0.07081 h 0.25155 l 0.12261,0.07081 v 0.30651 l -0.12261,0.07081 h -0.22618 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1423" />
+            <path
+               d="m 142.75281,26.828236 v -0.126832 h 0.26951 v 0.32025 l -0.1226,0.07081 h -0.29911 l -0.1226,-0.07081 v -0.608791 l 0.1226,-0.07082 h 0.29911 l 0.1226,0.07082 v 0.15114 h -0.14797 v -0.09512 h -0.24837 v 0.496757 h 0.24837 v -0.137401 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1425" />
+            <path
+               d="m 143.19143,26.594654 v -0.138457 l 0.19025,-0.108864 h 0.12683 v 0.613019 h 0.16911 v 0.126832 h -0.48619 v -0.126832 h 0.16911 v -0.462935 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1427" />
+          </g>
         </g>
         <g
            id="g4009"
            style="opacity:0.736082;fill:#ffffff;fill-opacity:1"
            transform="matrix(-1.1061792,0,0,1.1061792,-589.15206,-17.983519)">
-          <rect
-             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+          <path
              id="rect4001"
-             width="2.7561522"
-             height="0.19935799"
-             x="141.00124"
-             y="27.404345"
-             transform="scale(-1,1)" />
-          <text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832"
-             x="141.05009"
-             y="26.128925"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.032281;stroke-linejoin:round;stroke-dashoffset:59.5276;paint-order:stroke fill markers;stop-color:#000000"
+             transform="scale(-1,1)"
+             d="m 141.00124,27.404345 h 2.75615 v 0.199358 h -2.75615 z" />
+          <g
+             aria-label="6488
+9084"
+             transform="scale(-1,1)"
              id="text4007"
-             transform="scale(-1,1)"><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="26.128925"
+             style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:1.05693px;line-height:0.9;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Heavy';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;opacity:0.809713;mix-blend-mode:hard-light;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0719832">
+            <path
+               d="m 141.2879,25.510621 v 0.212443 l 0.0751,-0.04333 h 0.15642 l 0.12261,0.07081 v 0.312852 l -0.12261,0.07081 h -0.25683 l -0.12261,-0.07081 v -0.608792 l 0.12261,-0.07081 h 0.25683 l 0.12261,0.07081 v 0.151141 h -0.14797 v -0.09512 z m 0,0.295941 v 0.200816 h 0.20611 v -0.200816 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan4003">6488</tspan><tspan
-               sodipodi:role="line"
-               x="141.05009"
-               y="27.087183"
+               id="path1431" />
+            <path
+               d="m 142.26556,25.965101 v 0.163824 h -0.14585 v -0.163824 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13 v 0.456594 h 0.0909 v 0.119433 z m -0.33293,-0.119433 h 0.18708 v -0.238866 h -0.002 l -0.18496,0.236752 z"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
-               id="tspan4005">9084</tspan></text>
+               id="path1433" />
+            <path
+               d="m 142.64183,26.007378 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324477 h 0.21667 v -0.17228 h -0.21667 z m 0.24204,0.451309 h -0.28432 l -0.10569,-0.07081 V 25.80022 l 0.0919,-0.05285 v -0.0021 l -0.0919,-0.05285 v -0.237809 l 0.1226,-0.07081 h 0.26741 l 0.1226,0.07081 v 0.237809 l -0.0919,0.05285 v 0.0021 l 0.0919,0.05285 v 0.263176 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1435" />
+            <path
+               d="m 143.33412,26.007378 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324477 h 0.21667 v -0.17228 h -0.21667 z m 0.24203,0.451309 h -0.28431 l -0.10569,-0.07081 V 25.80022 l 0.0919,-0.05285 v -0.0021 l -0.0919,-0.05285 v -0.237809 l 0.1226,-0.07081 h 0.2674 l 0.12261,0.07081 v 0.237809 l -0.092,0.05285 v 0.0021 l 0.092,0.05285 v 0.263176 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1437" />
+            <path
+               d="m 141.49401,26.965637 v -0.212443 l -0.0751,0.04333 h -0.15642 l -0.12261,-0.07081 v -0.312851 l 0.12261,-0.07082 h 0.25683 l 0.12261,0.07082 v 0.608791 l -0.12261,0.07081 h -0.25683 l -0.12261,-0.07081 v -0.151141 h 0.14797 v 0.09512 z m 0,-0.295941 V 26.46888 h -0.20611 v 0.200816 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1439" />
+            <path
+               d="m 142.3554,27.021654 -0.1226,0.07081 h -0.28854 l -0.12261,-0.07081 v -0.608791 l 0.12261,-0.07082 h 0.28854 l 0.1226,0.07082 z m -0.38578,-0.552774 v 0.496757 h 0.23781 V 26.46888 Z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1441" />
+            <path
+               d="m 142.68305,26.965637 h 0.21667 v -0.197646 h -0.21667 z m 0,-0.324478 h 0.21667 V 26.46888 h -0.21667 z m 0.24204,0.451309 h -0.28432 l -0.10569,-0.07081 v -0.263175 l 0.0919,-0.05285 v -0.0021 l -0.0919,-0.05285 v -0.237809 l 0.1226,-0.07082 h 0.26741 l 0.1226,0.07082 v 0.237809 l -0.0919,0.05285 v 0.0021 l 0.0919,0.05285 v 0.263175 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1443" />
+            <path
+               d="m 143.67128,26.92336 v 0.163824 h -0.14586 V 26.92336 h -0.3509 v -0.105693 l 0.36675,-0.470334 h 0.13001 v 0.456594 h 0.0909 v 0.119433 z m -0.33294,-0.119433 h 0.18708 V 26.56506 h -0.002 l -0.18497,0.236753 z"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:1.05693px;font-family:Quantico;-inkscape-font-specification:'Quantico Bold';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.0719832"
+               id="path1445" />
+          </g>
         </g>
       </g>
     </g>


### PR DESCRIPTION
I am not sure why this pull request shows those two empty commits by @jasonbrooks, maybe I messed something in my merge? Anyway, the logo is now fixed and should look more normal.