### PR TITLE
cleaned up the tables to avoid wrapping

### DIFF
--- a/schedule.md
+++ b/schedule.md
@@ -22,16 +22,16 @@ Tuesday's themes are:
 * OCI innovations to the container format
 
 
-| EST time | UTC time | Session Title | Session Leader |
-| -------- | ------ | ---------------------------------------- | ---------- |
-| 9:30-9:55 AM | 14:30-14:55 | [Welcome and Logistics](/sessions/welcomeand) | Dan Walsh |
-| 10:00-10:55 AM | 15:00-15:55 | [DISCUSSION: New Kernel Features for Containers](/sessions/newkernelf) | Giuseppe Scrivano |
-| 11:00-11:25 AM | 16:00-16:25 | [Podman and systemd – the Why, the What, and the How](/sessions/podmanands) | Valentin Rothberg |
-| 11:30-11:55 AM | 16:30-16:55 | [Lightweight Virtualization-Based Isolation Using libkrun](/sessions/lightweigh) | Sergio Lopez |
-| 12:00-12:25 PM | 17:00-17:25 | [Container Migration News](/sessions/containerm) | Adrian Reber |
-| 12:30-12:55 PM | 17:30-17:55 | [Spooky Filesystems](/sessions/spookyfile) | Tammer Saleh |
-| 01:00-01:25 PM | 18:00-18:25 | [Challenges of Using User Namespaces at Big Scale](/sessions/challenges) | Mauricio Vásquez |
-| 01:30-01:55 PM | 18:30-18:55 | [OCI Artifacts: Adding Support for Reference Types](/sessions/ociartifac) | Steve Lasker |
+| EST&nbsp;time | UTC&nbsp;time | Session Title | Session Leader |
+| :-----------: | :-----------: | ------------- | -------------- |
+| 09:30&nbsp;AM | 14:30 | [Welcome and Logistics](/sessions/welcomeand) | Dan Walsh |
+| 10:00&nbsp;AM | 15:00 | [DISCUSSION: New Kernel Features for Containers](/sessions/newkernelf) | Giuseppe Scrivano |
+| 11:00&nbsp;AM | 16:00 | [Podman and systemd – the Why, the What, and the How](/sessions/podmanands) | Valentin Rothberg |
+| 11:30&nbsp;AM | 16:30 | [Lightweight Virtualization-Based Isolation Using libkrun](/sessions/lightweigh) | Sergio Lopez |
+| 12:00&nbsp;PM | 17:00 | [Container Migration News](/sessions/containerm) | Adrian Reber |
+| 12:30&nbsp;PM | 17:30 | [Spooky Filesystems](/sessions/spookyfile) | Tammer Saleh |
+| 01:00&nbsp;PM | 18:00 | [Challenges of Using User Namespaces at Big Scale](/sessions/challenges) | Mauricio Vásquez |
+| 01:30&nbsp;PM | 18:30 | [OCI Artifacts: Adding Support for Reference Types](/sessions/ociartifac) | Steve Lasker |
 
 ## Wednesday, March 10th
 
@@ -41,13 +41,13 @@ Wednesday's themes are:
 * Container image supply chain security
 * New ways to build container images
 
-| EST time | UTC time | Session Title | Session Leader |
-| ------ | ------ | ---------------------------------------- | ---------- |
-| 09:30-09:55 AM | 14:30-14:55 | [Nydus: Container Image Acceleration with E2E Data Integrity](/sessions/nydusconta) | Tao Peng |
-| 10:00-10:25AM | 15:00-15:25 | [Starting up Containers Super Fast With Lazy Pulling of Images](/sessions/startingup) | Kohei Tokunaga |
-| 10:30-10:55 AM | 15:30-15:55 | [DISCUSSION: Improve Image Pulls ](/sessions/improveima) | Giuseppe Scrivano |
-| 11:00-11:25 AM | 16:00-16:25 | [CoreOS vs IOT](/sessions/coreosiot) | TBD |
-| 11:30-11:55 AM | 16:30-16:55 | [Zero Trust: Running Confidential Computing Containers](/sessions/zerotrustr) | Samuel Ortiz |
-| 12:00-12:25 PM | 17:00-17:25 | [BuildKit: Intro to the Architecture of a Modern Build Framework](/sessions/buildkitin) | Tonis Tiigi |
-| 12:30-12:55 PM | 17:30-17:55 | [From Docker Compose to Kubernetes with Podman](/sessions/fromdocker) | Brent Baude |
-| 01:00-01:55PM | 18:00-18:55 | [DISCUSSION: Secure Container Supply Chain - Considerations, Tools, and Gaps](/sessions/securecont) | Nisha Kumar |
+| EST&nbsp;time | UTC&nbsp;time | Session Title | Session Leader |
+| :-----------: | :-----------: | ------------- | -------------- |
+| 09:30&nbsp;AM | 14:30 | [Nydus: Container Image Acceleration with E2E Data Integrity](/sessions/nydusconta) | Tao Peng |
+| 10:00&nbsp;AM | 15:00 | [Starting up Containers Super Fast With Lazy Pulling of Images](/sessions/startingup) | Kohei Tokunaga |
+| 10:30&nbsp;AM | 15:30 | [DISCUSSION: Improve Image Pulls ](/sessions/improveima) | Giuseppe Scrivano |
+| 11:00&nbsp;AM | 16:00 | [CoreOS vs IOT](/sessions/coreosiot) | TBD |
+| 11:30&nbsp;AM | 16:30 | [Zero Trust: Running Confidential Computing Containers](/sessions/zerotrustr) | Samuel Ortiz |
+| 12:00&nbsp;PM | 17:00 | [BuildKit: Intro to the Architecture of a Modern Build Framework](/sessions/buildkitin) | Tonis Tiigi |
+| 12:30&nbsp;PM | 17:30 | [From Docker Compose to Kubernetes with Podman](/sessions/fromdocker) | Brent Baude |
+| 01:00&nbsp;PM | 18:00 | [DISCUSSION: Secure Container Supply Chain - Considerations, Tools, and Gaps](/sessions/securecont) | Nisha Kumar |


### PR DESCRIPTION
  * Removed ending times as redundant, makes it easier to read the content,
  * Made the time columns not wrap with non-breaking spaces in column headers and between time and AM/PM. While this looks a bit ugly in the markdown source file, it works.

Example:
![image](https://user-images.githubusercontent.com/2587818/109658925-cfa1b600-7b6f-11eb-918b-92983b8a1581.png)
